### PR TITLE
fix: Fixed linux not exiting the launcher and editor

### DIFF
--- a/src/launcher/launcher.cpp
+++ b/src/launcher/launcher.cpp
@@ -144,7 +144,7 @@ int32_t main(int32_t argc, char* argv[])
 	
 	LOCK_VARIABLE(framecnt);
 	LOCK_FUNCTION(fps_callback);
-	
+
 	if(install_int_ex(fps_callback,SECS_TO_TIMER(1)))
 	{
 		Z_error_fatal("couldn't allocate timer\n");
@@ -258,11 +258,11 @@ int32_t main(int32_t argc, char* argv[])
 	set_close_button_callback((void (*)()) hit_close_button);
 	//
 	Z_message("Launcher opened successfully.\n");
-	
+
 	#if QUICK_EXIT > 0
 	goto exit;
 	#endif
-	
+
 	LauncherDialog().show();
 
 	#if QUICK_EXIT > 0
@@ -272,6 +272,7 @@ int32_t main(int32_t argc, char* argv[])
 	//
 	
 	flush_config_file();
+	allegro_exit();
 	return 0;
 }
 END_OF_MAIN()

--- a/src/zq/zquest.cpp
+++ b/src/zq/zquest.cpp
@@ -25188,7 +25188,7 @@ bool can_use_item([[maybe_unused]] int32_t item_type, [[maybe_unused]] int32_t i
 	return true;
 }
 
-bool has_item(int32_t [[maybe_unused]] item_type, [[maybe_unused]] int32_t it)
+bool has_item([[maybe_unused]] int32_t tem_type, [[maybe_unused]] int32_t it)
 {
 	return true;
 }
@@ -26385,7 +26385,8 @@ int32_t main(int32_t argc,char **argv)
 	
 	if(ForceExit) //last resort fix to the allegro process hanging bug.
 		exit(0);
-	
+
+	allegro_exit();
 	return 0;
 // memset(qtpathtitle,0,10);//UNREACHABLE
 }
@@ -27796,7 +27797,7 @@ void check_autosave()
 }
 
 void flushItemCache(bool) {}
-void ringcolor(bool [[maybe_unused]] forceDefault)
+void ringcolor([[maybe_unused]] bool forceDefault)
 {
 }
 


### PR DESCRIPTION
This is due to allegro trying lock while trying normally exit.